### PR TITLE
Implement filtered loading

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,26 @@ jobs:
         node-version: [10, 12, 14]
         os: [ubuntu-latest]
 
+    services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub image
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_USER: casbin_objection_adapter_test_user
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: casbin_objection_adapter_test
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+
     steps:
       - uses: actions/checkout@v1
       - uses: volta-cli/action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ lerna-debug.log*
 /docs
 
 *.sqlite
+.vscode
+scripts/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - [Installation](#installation)
 - [Basic usage](#basic-usage)
 - [Advanced usage](#advanced-usage)
+    + [Filtered policy loading](#filtered-policy-loading)
 
 <!-- tocstop -->
 
@@ -70,3 +71,42 @@ The following options are available:
 | `createTable` | `true`        | Whether or not to create the table when initialized.                                                            |
 | `modelClass`  | `CasbinRule`  | The model to use when querying policies. You can override this if you would like to control the table name      |
 | `logger`      | `noop`        | An optional logger in case additional visiblity is needed into the adapter. The inteface should match `console` |
+
+#### Filtered policy loading
+
+This adapter supports filtered policy loading as of v0.3.1.
+Policies are filtered using the `loadFilteredPolicy` function on the enforcer. Note that loading a filtered policy clears the in memory policy data. This is a feature of Casbin and not this adapter.
+Filter examples taken from [casbin-pg-adapter](https://github.com/touchifyapp/casbin-pg-adapter)
+
+The filters take an object with keys refering to the ptype of the filter, and values containing an array of filter values.
+Any empty string, undefined, or null value is ignored in the filter. Plain strings (such as those used in the simple filter example below) are
+tested for simple equality.
+Strings prefixed with `regex:` or `like:` are tested using pattern matching.
+
+Simple filter example:
+
+```js
+await enforcer.loadFilteredPolicy({
+  p: ["alice"],
+  g: ["", "role:admin"],
+});
+```
+
+Using the above filter, you will get:
+
+- all records with `ptype` of p, and subject of `admin`
+- and all records with `ptype` of g, and a second argument of `admin`
+
+Complex filter example:
+
+```js
+await enforcer.loadFilteredPolicy({
+  p: ["regex:(role:.*)|(alice)"],
+  g: ["", "like:role:%"],
+});
+```
+
+Using the above filter you will get:
+
+- all records with `ptype` of p, and subjects that match the regex `(role:.*)|(alice)`
+- and all records with `ptype` of g, and a second argument that is `like` `role:%`

--- a/README.md
+++ b/README.md
@@ -75,12 +75,16 @@ The following options are available:
 #### Filtered policy loading
 
 This adapter supports filtered policy loading as of v0.3.1.
+
 Policies are filtered using the `loadFilteredPolicy` function on the enforcer. Note that loading a filtered policy clears the in memory policy data. This is a feature of Casbin and not this adapter.
+
 Filter examples taken from [casbin-pg-adapter](https://github.com/touchifyapp/casbin-pg-adapter)
 
 The filters take an object with keys refering to the ptype of the filter, and values containing an array of filter values.
-Any empty string, undefined, or null value is ignored in the filter. Plain strings (such as those used in the simple filter example below) are
-tested for simple equality.
+
+Any empty string, undefined, or null value is ignored in the filter.
+
+Plain strings (such as those used in the simple filter example below) are tested for simple equality.
 Strings prefixed with `regex:` or `like:` are tested using pattern matching.
 
 Simple filter example:

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@typescript-eslint/eslint-plugin": "~2.34.0",
     "@typescript-eslint/parser": "~2.34.0",
     "babel-jest": "~26.0.1",
-    "casbin": "~5.0.0",
+    "casbin": "~5.0.5",
     "eslint": "~7.0.0",
     "eslint-config-prettier": "~6.11.0",
     "eslint-plugin-jest": "~23.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casbin-objection-adapter",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "description": "",
   "keywords": [
     "casbin",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "lint-staged": "~10.2.4",
     "markdown-toc": "~1.2.0",
     "objection": "~2.1.3",
+    "pg": "^8.3.0",
     "prettier": "~2.0.5",
     "prettier-plugin-organize-imports": "~1.0.4",
     "prettier-plugin-packagejson": "~2.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,10 +17,11 @@ devDependencies:
   eslint-plugin-jest: 23.13.1_eslint@7.0.0+typescript@3.9.2
   husky: 4.2.5
   jest: 26.0.1
-  knex: 0.21.1_sqlite3@4.2.0
+  knex: 0.21.1_pg@8.3.0+sqlite3@4.2.0
   lint-staged: 10.2.4
   markdown-toc: 1.2.0
   objection: 2.1.3_knex@0.21.1
+  pg: 8.3.0_pg@8.3.0
   prettier: 2.0.5
   prettier-plugin-organize-imports: 1.0.4_prettier@2.0.5+typescript@3.9.2
   prettier-plugin-packagejson: 2.2.3_prettier@2.0.5
@@ -2155,6 +2156,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+  /buffer-writer/2.0.0:
+    dev: true
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==
   /builtins/1.0.3:
     dev: true
     resolution:
@@ -5300,7 +5307,7 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
-  /knex/0.21.1_sqlite3@4.2.0:
+  /knex/0.21.1_pg@8.3.0+sqlite3@4.2.0:
     dependencies:
       colorette: 1.1.0
       commander: 5.1.0
@@ -5312,6 +5319,7 @@ packages:
       liftoff: 3.1.0
       lodash: 4.17.15
       mkdirp: 1.0.4
+      pg: 8.3.0_pg@8.3.0
       pg-connection-string: 2.2.0
       sqlite3: 4.2.0
       tarn: 3.0.0
@@ -6274,7 +6282,7 @@ packages:
     dependencies:
       ajv: 6.12.2
       db-errors: 0.2.3
-      knex: 0.21.1_sqlite3@4.2.0
+      knex: 0.21.1_pg@8.3.0+sqlite3@4.2.0
     dev: true
     engines:
       node: '>=8.0.0'
@@ -6422,6 +6430,10 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+  /packet-reader/1.0.0:
+    dev: true
+    resolution:
+      integrity: sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==
   /pacote/11.1.9:
     dependencies:
       '@npmcli/git': 2.0.2
@@ -6611,6 +6623,63 @@ packages:
     dev: true
     resolution:
       integrity: sha512-xB/+wxcpFipUZOQcSzcgkjcNOosGhEoPSjz06jC89lv1dj7mc9bZv6wLVy8M2fVjP0a/xN0N988YDq1L0FhK3A==
+  /pg-connection-string/2.3.0:
+    dev: true
+    resolution:
+      integrity: sha512-ukMTJXLI7/hZIwTW7hGMZJ0Lj0S2XQBCJ4Shv4y1zgQ/vqVea+FLhzywvPj0ujSuofu+yA4MYHGZPTsgjBgJ+w==
+  /pg-int8/1.0.1:
+    dev: true
+    engines:
+      node: '>=4.0.0'
+    resolution:
+      integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
+  /pg-pool/3.2.1_pg@8.3.0:
+    dependencies:
+      pg: 8.3.0_pg@8.3.0
+    dev: true
+    peerDependencies:
+      pg: '>=8.0'
+    resolution:
+      integrity: sha512-BQDPWUeKenVrMMDN9opfns/kZo4lxmSWhIqo+cSAF7+lfi9ZclQbr9vfnlNaPr8wYF3UYjm5X0yPAhbcgqNOdA==
+  /pg-protocol/1.2.5:
+    dev: true
+    resolution:
+      integrity: sha512-1uYCckkuTfzz/FCefvavRywkowa6M5FohNMF5OjKrqo9PSR8gYc8poVmwwYQaBxhmQdBjhtP514eXy9/Us2xKg==
+  /pg-types/2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.0
+      postgres-date: 1.0.5
+      postgres-interval: 1.2.0
+    dev: true
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==
+  /pg/8.3.0_pg@8.3.0:
+    dependencies:
+      buffer-writer: 2.0.0
+      packet-reader: 1.0.0
+      pg-connection-string: 2.3.0
+      pg-pool: 3.2.1_pg@8.3.0
+      pg-protocol: 1.2.5
+      pg-types: 2.2.0
+      pgpass: 1.0.2
+      semver: 4.3.2
+    dev: true
+    engines:
+      node: '>= 8.0.0'
+    peerDependencies:
+      pg: '*'
+    resolution:
+      integrity: sha512-jQPKWHWxbI09s/Z9aUvoTbvGgoj98AU7FDCcQ7kdejupn/TcNpx56v2gaOTzXkzOajmOEJEdi9eTh9cA2RVAjQ==
+  /pgpass/1.0.2:
+    dependencies:
+      split: 1.0.1
+    dev: true
+    resolution:
+      integrity: sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=
   /picomatch/2.2.2:
     dev: true
     engines:
@@ -6685,6 +6754,32 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
+  /postgres-array/2.0.0:
+    dev: true
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==
+  /postgres-bytea/1.0.0:
+    dev: true
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=
+  /postgres-date/1.0.5:
+    dev: true
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-pdau6GRPERdAYUQwkBnGKxEfPyhVZXG/JiS44iZWiNdSOWE09N2lUgN6yshuq6fVSon4Pm0VMXd1srUUkLe9iA==
+  /postgres-interval/1.2.0:
+    dependencies:
+      xtend: 4.0.2
+    dev: true
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
   /prelude-ls/1.1.2:
     dev: true
     engines:
@@ -7338,6 +7433,11 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
+  /semver/4.3.2:
+    dev: true
+    hasBin: true
+    resolution:
+      integrity: sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=
   /semver/5.7.1:
     dev: true
     hasBin: true
@@ -8637,6 +8737,7 @@ specifiers:
   lint-staged: ~10.2.4
   markdown-toc: ~1.2.0
   objection: ~2.1.3
+  pg: ^8.3.0
   prettier: ~2.0.5
   prettier-plugin-organize-imports: ~1.0.4
   prettier-plugin-packagejson: ~2.2.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ devDependencies:
   '@typescript-eslint/eslint-plugin': 2.34.0_d88701cb3afea3dfd694e8456ddba8b7
   '@typescript-eslint/parser': 2.34.0_eslint@7.0.0+typescript@3.9.2
   babel-jest: 26.0.1_@babel+core@7.9.6
-  casbin: 5.0.0
+  casbin: 5.0.5
   eslint: 7.0.0
   eslint-config-prettier: 6.11.0_eslint@7.0.0
   eslint-plugin-jest: 23.13.1_eslint@7.0.0+typescript@3.9.2
@@ -2289,16 +2289,15 @@ packages:
       node: 6.* || 8.* || >= 10.*
     resolution:
       integrity: sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==
-  /casbin/5.0.0:
+  /casbin/5.0.5:
     dependencies:
       await-lock: 2.0.1
       expression-eval: 2.1.0
       ip: 1.1.5
-      lodash: 4.17.15
       micromatch: 4.0.2
     dev: true
     resolution:
-      integrity: sha512-mxc0voyWZLu/Wgm+kfn18Wc9bFzP8IAc8jVxYIqkyoZRqSa7eUmS73aU3S39y13XDssacVePsSNmxCjnnc+qRA==
+      integrity: sha512-PHwqiqnq4IcTgaJWsVL6TD64WzbRkPeLh2c3oEFmn1TV5fISGzDE+m92HX/FszRdqlvc2iOXSVh7YU0z4SQh3Q==
   /caseless/0.12.0:
     dev: true
     resolution:
@@ -8727,7 +8726,7 @@ specifiers:
   '@typescript-eslint/eslint-plugin': ~2.34.0
   '@typescript-eslint/parser': ~2.34.0
   babel-jest: ~26.0.1
-  casbin: ~5.0.0
+  casbin: ~5.0.5
   eslint: ~7.0.0
   eslint-config-prettier: ~6.11.0
   eslint-plugin-jest: ~23.13.1

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -46,11 +46,11 @@ export class ObjectionAdapter implements Adapter {
     return adapter;
   }
 
-  isFiltered(): boolean {
+  public isFiltered(): boolean {
     return this.filtered;
   }
 
-  setFiltered(isFiltered: boolean): void {
+  public enabledFiltered(isFiltered: boolean): void {
     this.filtered = isFiltered;
   }
 
@@ -85,7 +85,7 @@ export class ObjectionAdapter implements Adapter {
   }
 
   async loadPolicy(model: Model): Promise<void> {
-    this.setFiltered(false);
+    this.enabledFiltered(false);
     this.logger.log("Loading policy");
 
     const policies = await this.modelClass.query();
@@ -113,7 +113,7 @@ export class ObjectionAdapter implements Adapter {
     this.logger.log("Filter found %O", policies);
 
     this.loadPolicyLines(policies, model);
-    this.setFiltered(true);
+    this.enabledFiltered(true);
   }
 
   /**

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -1,0 +1,80 @@
+import Objection from "objection";
+import { CasbinFilter, CasbinRule, CasbinRuleFilter } from "./model";
+
+type ConditionObject = Record<string, string[]>;
+type FilterObject = Record<string, ConditionObject>;
+type ObjectionQueryModifier = "where" | "orWhere";
+
+function interpretConditions(conditionList: CasbinRuleFilter): ConditionObject {
+  const conditionObj: ConditionObject = {};
+  conditionList.forEach((cond, i) => {
+    if (cond === null || typeof cond === "undefined" || cond === "") return;
+    if (cond.startsWith("regex:")) {
+      conditionObj[`v${i}`] = ["~", cond.replace("regex:", "")];
+    } else if (cond.startsWith("like:")) {
+      conditionObj[`v${i}`] = ["ilike", cond.replace("like:", "")];
+    } else {
+      conditionObj[`v${i}`] = ["=", cond];
+    }
+  });
+  return conditionObj;
+}
+
+export function interpretFilter(filter: CasbinFilter): FilterObject {
+  const interpreted = Object.keys(filter).reduce(
+    (interpretedFilter: FilterObject, ptype) => {
+      interpretedFilter[ptype] = interpretConditions(filter[ptype]);
+      return interpretedFilter;
+    },
+    {},
+  );
+  return interpreted;
+}
+
+function addQueryConditions(
+  conditions: ConditionObject,
+  query: Objection.QueryBuilder<CasbinRule, CasbinRule[]>,
+): Objection.QueryBuilder<CasbinRule, CasbinRule[]> {
+  let _query = query;
+  Object.keys(conditions).forEach((cond) => {
+    const [op, val] = conditions[cond];
+    _query = _query.where(cond, op, val);
+  });
+  return _query;
+}
+
+function _createQuery(
+  filterObj: FilterObject,
+): (model: typeof CasbinRule) => Promise<CasbinRule[]> {
+  return (model) => {
+    let casbinQuery = model.query();
+    let queryModifier: ObjectionQueryModifier = "where";
+    Object.keys(filterObj).forEach((ptype, i) => {
+      if (i > 0) queryModifier = "orWhere";
+      casbinQuery = casbinQuery[queryModifier](function () {
+        addQueryConditions(filterObj[ptype], this.where("ptype", "=", ptype));
+      });
+    });
+    return casbinQuery;
+  };
+}
+
+const createFilterQuery = (
+  filterObj: FilterObject,
+  model: typeof CasbinRule,
+): Promise<CasbinRule[]> => _createQuery(filterObj)(model);
+
+export function useFilterQuery(
+  queryObject: FilterObject,
+  model: typeof CasbinRule,
+): Promise<CasbinRule[]> {
+  return createFilterQuery(queryObject, model);
+}
+
+export function getFilteredPolicies(
+  filter: CasbinFilter,
+  model: typeof CasbinRule,
+): Promise<CasbinRule[]> {
+  const policyFilter = interpretFilter(filter);
+  return useFilterQuery(policyFilter, model);
+}

--- a/src/model.ts
+++ b/src/model.ts
@@ -23,3 +23,6 @@ export class CasbinRule extends objection.Model {
   v4!: string;
   v5!: string;
 }
+
+export type CasbinRuleFilter = Array<string | null | undefined>;
+export type CasbinFilter = Record<string, CasbinRuleFilter>;

--- a/test/abac/adapter.spec.ts
+++ b/test/abac/adapter.spec.ts
@@ -9,7 +9,7 @@ describe("ObjectionAdapter (ABAC)", () => {
   let data1: TestResource;
   let data2: TestResource;
 
-  const knex = makeAndConfigureDatabase(__dirname);
+  const knex = makeAndConfigureDatabase();
 
   class TestResource {
     public Name: string;

--- a/test/acl/adapter.spec.ts
+++ b/test/acl/adapter.spec.ts
@@ -13,7 +13,7 @@ describe("ObjectionAdapter (ACL)", () => {
     stark: ["tony", "data3", "root"],
   };
 
-  const knex = makeAndConfigureDatabase(__dirname);
+  const knex = makeAndConfigureDatabase();
 
   beforeEach(async () => {
     adapter = await ObjectionAdapter.newAdapter(knex);

--- a/test/adapter.spec.ts
+++ b/test/adapter.spec.ts
@@ -8,9 +8,10 @@ describe("ObjectionAdapter", () => {
   let adapter: ObjectionAdapter;
   let enforcer: Enforcer;
 
-  const knex = makeAndConfigureDatabase(__dirname);
+  const knex = makeAndConfigureDatabase();
 
   beforeEach(async () => {
+    await knex.raw(`select 1+1 as result`);
     adapter = await ObjectionAdapter.newAdapter(knex);
 
     enforcer = await newEnforcer(

--- a/test/rbac/adapter.spec.ts
+++ b/test/rbac/adapter.spec.ts
@@ -14,7 +14,7 @@ describe("ObjectionAdapter (RBAC)", () => {
     data2AdminWrite: ["data2_admin", "data2", "write"],
   };
 
-  const knex = makeAndConfigureDatabase(__dirname);
+  const knex = makeAndConfigureDatabase();
 
   beforeEach(async () => {
     adapter = await ObjectionAdapter.newAdapter(knex);

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,13 +1,14 @@
 import Knex from "knex";
-import * as path from "path";
 
-export function makeAndConfigureDatabase(dirname: string): Knex {
+export function makeAndConfigureDatabase(): Knex {
   const knex = Knex({
-    client: "sqlite3",
+    client: "pg",
     useNullAsDefault: true,
     asyncStackTraces: true,
     connection: {
-      filename: path.join(dirname, "casbin.sqlite"),
+      user: "casbin_objection_adapter_test_user",
+      password: "password",
+      database: "casbin_objection_adapter_test",
     },
   });
 


### PR DESCRIPTION
Added filtered loading support to the adapter.

Added `loadFilteredPolicy` to the adapter, which takes in a query object. This query object is then interpreted into a chained knex query to load the filtered policies from the database.

Queries can be made using simple equality searches as well as more complex pattern matching in the form of `like:` and `regex:`

Added tests to validate the filtered loading for both simple and complex queries.

### TODO
Update readme & publish.